### PR TITLE
Add imageUrls where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ hs_err_pid*
 *.properties
 target/
 build/
+out/
 !system.properties
 .gradle/
 !src/test/resources/credentials.properties

--- a/src/main/java/com/tibiawiki/domain/repositories/ArticleRepository.java
+++ b/src/main/java/com/tibiawiki/domain/repositories/ArticleRepository.java
@@ -3,12 +3,14 @@ package com.tibiawiki.domain.repositories;
 import benjaminkomen.jwiki.core.MQuery;
 import benjaminkomen.jwiki.core.NS;
 import benjaminkomen.jwiki.core.Wiki;
+import benjaminkomen.jwiki.dwrap.ImageInfo;
 import com.tibiawiki.domain.utils.PropertiesUtil;
 import okhttp3.HttpUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -72,6 +74,17 @@ public class ArticleRepository {
         return isDebugEnabled
                 ? true
                 : wiki.edit(pageName, pageContent, editSummary);
+    }
+
+    /**
+     * If an image has multiple revisions, a list of them is returned. The first one is the newest one, which we want.
+     */
+    public String getFile(String fileName) {
+        return wiki.getImageInfo(fileName).stream()
+                .max(Comparator.comparing(ImageInfo::getTimestamp))
+                .map(ImageInfo::getUrl)
+                .map(HttpUrl::toString)
+                .orElse(null);
     }
 
     protected void enableDebug() {

--- a/src/main/java/com/tibiawiki/process/RetrieveAny.java
+++ b/src/main/java/com/tibiawiki/process/RetrieveAny.java
@@ -33,6 +33,10 @@ public abstract class RetrieveAny {
                 .map(jsonFactory::convertInfoboxPartOfArticleToJson);
     }
 
+    public Optional<String> getFileUrl(String fileName) {
+        return Optional.ofNullable(articleRepository.getFile(fileName));
+    }
+
     public Stream<JSONObject> getArticlesFromInfoboxTemplateAsJSON(List<String> pageNames) {
         return Stream.of(pageNames)
                 .flatMap(lst -> articleRepository.getArticlesFromCategory(lst).entrySet().stream())

--- a/src/main/java/com/tibiawiki/process/RetrieveCreatures.java
+++ b/src/main/java/com/tibiawiki/process/RetrieveCreatures.java
@@ -37,4 +37,8 @@ public class RetrieveCreatures extends RetrieveAny {
     public Optional<JSONObject> getCreatureJSON(String pageName) {
         return super.getArticleAsJSON(pageName);
     }
+
+    public Optional<String> getCreatureImageUrl(String name) {
+        return super.getFileUrl(String.format("File:%s.gif", name));
+    }
 }

--- a/src/main/java/com/tibiawiki/serviceinterface/CreaturesResource.java
+++ b/src/main/java/com/tibiawiki/serviceinterface/CreaturesResource.java
@@ -56,6 +56,19 @@ public class CreaturesResource {
     }
 
     @GET
+    @Path("/{name}/image")
+    @ApiOperation(value = "Get the image url of a specific creature by name")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getImageUrlOfCreatureByName(@PathParam("name") String name) {
+        return retrieveCreatures.getCreatureImageUrl(name)
+                .map(str -> Response.ok()
+                        .entity(str)
+                        .build())
+                .orElseGet(() -> Response.status(Response.Status.NOT_FOUND)
+                        .build());
+    }
+
+    @GET
     @Path("/{name}")
     @ApiOperation(value = "Get a specific creature by name")
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Mvp based on this ticket: https://github.com/benjaminkomen/TibiaWikiApi/issues/75

Possible implementations:
- separate resource (like mvp)
- Adding parameter in JSON: do 2 calls to MediaWiki API to retrieve a single creature/item/.. one for the article, a second for the image.
- Adding parameter in JSON: do 2 calls to MediaWiki API to retrieve an expanded list of creatures/items/..., one for all the article texts, one for all the images.

This last thing would be cool, but we need to check if it's possible and performing.